### PR TITLE
Pass TFC_ORG_TOKEN securely

### DIFF
--- a/iam.tf
+++ b/iam.tf
@@ -18,8 +18,26 @@ data "aws_iam_policy" "ecs-task-execution-role" {
   name = "AmazonECSTaskExecutionRolePolicy"
 }
 
+# SSM needed for secrets
+resource "aws_iam_policy" "ssm-get-parameters" {
+  name = "ssm-get-parameters-${local.name}"
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = [
+          "ssm:GetParameters",
+        ]
+        Effect   = "Allow"
+        Resource = "*"
+      },
+    ]
+  })
+}
+
 resource "aws_iam_role" "ecs-task-execution-role" {
-  name               = "ecs-task-execution-role-tfc-audit-trail"
+  name               = "ecs-task-execution-role-${local.name}"
   assume_role_policy = data.aws_iam_policy_document.assume_role_policy.json
 }
 
@@ -28,13 +46,18 @@ resource "aws_iam_role_policy_attachment" "attach-ecs-task-execution-role" {
   policy_arn = data.aws_iam_policy.ecs-task-execution-role.arn
 }
 
+resource "aws_iam_role_policy_attachment" "attach-ssm-get-parameters" {
+  role       = aws_iam_role.ecs-task-execution-role.name
+  policy_arn = aws_iam_policy.ssm-get-parameters.arn
+}
+
 # Vector Role
 data "aws_iam_policy" "cloudwatch-logs-full" {
   name = "CloudWatchLogsFullAccess"
 }
 
 resource "aws_iam_role" "vector" {
-  name               = "vector-cloudwatch-logs"
+  name               = "vector-cloudwatch-logs-${local.name}"
   assume_role_policy = data.aws_iam_policy_document.assume_role_policy.json
 }
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,5 +1,5 @@
 output "audit_trail_log_group" {
-  description = "Name of the CloudWatch log group containing the audit trail stream."
+  description = "Name of the CloudWatch log group containing the audit trail stream and vector stream."
   value       = aws_cloudwatch_log_group.tfc-audit-trail.name
 }
 

--- a/vector.toml.tftpl
+++ b/vector.toml.tftpl
@@ -4,7 +4,7 @@ endpoint = "${endpoint}?page[size]=${page_size}"
 scrape_interval_secs = ${scrape_interval_secs}
 [sources.tfc_audit_trail.auth]
 strategy = "bearer"
-token = "${token}"
+token = "$TFC_ORG_TOKEN"
 
 [transforms.remap_data]
 inputs = [ "tfc_audit_trail"]

--- a/vpc.tf
+++ b/vpc.tf
@@ -1,10 +1,10 @@
 data "aws_availability_zones" "available" {}
 
 module "tfc-audit-trail-vpc" {
-  source = "terraform-aws-modules/vpc/aws"
+  source  = "terraform-aws-modules/vpc/aws"
   version = "3.18.1"
 
-  name = "tfc-audit-trail"
+  name = local.name
   cidr = "10.0.0.0/16"
 
   azs            = data.aws_availability_zones.available.names


### PR DESCRIPTION
Use SSM to securely load the TFC_ORG_TOKEN as an environment variable into Vector (via the secrets container definition field, meaning it will not be visible in the AWS console). This means Terraform no longer renders the secret in plaintext into the config file, it is referenced by Vector config.